### PR TITLE
Fix incorrectly imported static objects from ssh2

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,8 +14,8 @@ const {getLogicalDisks, wslpath, winpath} = require('./utils/');
 const IS_WIN32 = os.platform() == "win32";
 //from stream scope
 
-var SFTP_OPEN_MODE, SFTP_STATUS_CODE;
-var flagsToString;
+const {flagsToString, OPEN_MODE : SFTP_OPEN_MODE, STATUS_CODE : SFTP_STATUS_CODE} = require('ssh2').utils.sftp;
+
 
 function pathRemoteToLocal(remotepath) {
   if(IS_WIN32)
@@ -82,10 +82,7 @@ const modeLinux = (filename, filepath) => {
 class SFTP {
 
   constructor(sftpStream) {
-
-    ({flagsToString} = sftpStream.constructor);
-    ({OPEN_MODE : SFTP_OPEN_MODE, STATUS_CODE : SFTP_STATUS_CODE} = sftpStream.constructor);
-
+    
     this.openFiles = {};
     this._handleCount = 0;
     this.sftpStream = sftpStream;


### PR DESCRIPTION
See changes, pretty self explanatory. Fixes a lovely error that looks like:

events.js:292
      throw er; // Unhandled 'error' event
      ^

TypeError: Cannot read property 'READ' of undefined
    at SFTP._opendir (...\node_modules\ssh2-sftp-server\index.js:168:57)
    at SFTP.emit (events.js:315:20)
    at 11 (...\node_modules\ssh2\lib\protocol\SFTP.js:2923:15)
    at SFTP.push (...\node_modules\ssh2\lib\protocol\SFTP.js:271:11)
    at CHANNEL_DATA (...\node_modules\ssh2\lib\server.js:743:23)
    at 94 (...\node_modules\ssh2\lib\protocol\handlers.misc.js:841:16)
    at Protocol.onPayload (...\node_modules\ssh2\lib\protocol\Protocol.js:1974:10)
    at AESGCMDecipherNative.decrypt (...\node_modules\ssh2\lib\protocol\crypto.js:992:26)
    at Protocol.parsePacket [as _parse] (...\node_modules\ssh2\lib\protocol\Protocol.js:1943:25)
    at Protocol.parse (...\node_modules\ssh2\lib\protocol\Protocol.js:281:16)
Emitted 'error' event on Client instance at:
    at Socket.<anonymous> (...\node_modules\ssh2\lib\server.js:1201:16)
    at Socket.emit (events.js:315:20)
    at addChunk (internal/streams/readable.js:309:12)
    at readableAddChunk (internal/streams/readable.js:284:9)
    at Socket.Readable.push (internal/streams/readable.js:223:10)
    at TCP.onStreamRead (internal/stream_base_commons.js:188:23)
