### PR TITLE
Fix README code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ support most of client requests:
 
 # Usage
 
-```
+```js
 "use strict";
 
 const fs         = require('fs');
@@ -55,9 +55,9 @@ new ssh2.Server({
     ctx.accept();
   }).on('ready', function() {
     client.on('session', (accept) => {
-      let session = accept();
-      session.on('sftp', function() {
-        var sftpStream = accept();
+      const session = accept();
+      session.on('sftp', (accept) => {
+        const sftpStream = accept();
         new SftpServer(sftpStream);
       });
     });


### PR DESCRIPTION
`session.on('sftp')` provides another `accept` callback, that needs to be used.  Simply calling the `accept` callback provided to the on-session handle does not work.